### PR TITLE
feat: adicionar mapeamento inicial da entidade Aluno com repositório,…

### DIFF
--- a/src/main/java/br/com/student/portal/controller/StudentController.java
+++ b/src/main/java/br/com/student/portal/controller/StudentController.java
@@ -1,0 +1,19 @@
+package br.com.student.portal.controller;
+
+
+import br.com.student.portal.service.StudentService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/student")
+public class StudentController {
+
+
+    @Autowired
+    private StudentService studentService;
+
+
+
+}

--- a/src/main/java/br/com/student/portal/model/Student.java
+++ b/src/main/java/br/com/student/portal/model/Student.java
@@ -1,0 +1,28 @@
+package br.com.student.portal.model;
+
+
+import jakarta.persistence.*;
+import lombok.Data;
+
+import java.util.UUID;
+
+@Entity
+@Data
+@Table(name = "student")
+public class Student {
+
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private UUID id;
+
+    private String name;
+
+    private String registration;
+
+    private String course;
+
+
+
+
+}

--- a/src/main/java/br/com/student/portal/repository/StudentRepository.java
+++ b/src/main/java/br/com/student/portal/repository/StudentRepository.java
@@ -1,0 +1,11 @@
+package br.com.student.portal.repository;
+
+import br.com.student.portal.model.Student;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.UUID;
+
+@Repository
+public interface StudentRepository extends JpaRepository<Student, UUID> {
+}

--- a/src/main/java/br/com/student/portal/service/StudentService.java
+++ b/src/main/java/br/com/student/portal/service/StudentService.java
@@ -1,0 +1,15 @@
+package br.com.student.portal.service;
+
+
+import br.com.student.portal.repository.StudentRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class StudentService {
+
+    @Autowired
+    private StudentRepository studentRepository;
+
+
+}


### PR DESCRIPTION
Este PR implementa o mapeamento inicial da entidade Aluno no projeto. As principais mudanças incluem:

- Criação da entidade Aluno com seus atributos principais e anotações JPA.
- Implementação do repositório para operações básicas de persistência.
- Desenvolvimento do serviço para encapsular as regras de negócio relacionadas a Aluno.
- Criação do controlador para expor os endpoints relacionados à entidade.